### PR TITLE
Change init.d invocation to use invoke-rc.d

### DIFF
--- a/debian-tei-oxgarage/debian/postinst
+++ b/debian-tei-oxgarage/debian/postinst
@@ -1,6 +1,11 @@
 #!/bin/sh
 chown -R tomcat7:tomcat7 /var/cache/oxgarage
 perl -p -i -e "s/localhost/`hostname -f`/" /var/lib/tomcat7/webapps/ege-webclient/WEB-INF/web.xml
-/etc/init.d/tomcat7 restart
+
+if which invoke-rc.d >/dev/null 2>&1; then
+  invoke-rc.d tomcat7 restart
+else
+  /etc/init.d/tomcat7 restart
+fi
 
 


### PR DESCRIPTION
This is the correct way to restart services from within a `postinst`: https://www.debian.org/doc/debian-policy/ch-opersys.html#s9.3.3.2

Invoke-rc.d takes into account the current runlevel, which is important for various reasons, one of which is creating Docker images. There is also a bug in the tomcat7 init.d script (or somewhere in this chain), which manages to fail within a Docker environment, so the building of a Docker image fails.