### PR TITLE
Ignore fonts directory as a source of input files

### DIFF
--- a/tei-converter/src/main/java/pl/psnc/dl/ege/tei/TEIConverter.java
+++ b/tei-converter/src/main/java/pl/psnc/dl/ege/tei/TEIConverter.java
@@ -89,6 +89,8 @@ public class TEIConverter implements Converter,ErrorHandler {
 
 	// List of directories which might contain images for input type
 	private static final List<String> imagesInputDirectories = Arrays.asList(new String[] {"media", "Pictures"});
+	// List of directories which might contain fonts
+	private static final List<String> fontsInputDirectories = Arrays.asList(new String[] {"fonts"});
 
 	private static final Logger LOGGER = Logger.getLogger(TEIConverter.class);
 
@@ -467,7 +469,9 @@ public class TEIConverter implements Converter,ErrorHandler {
 		for (File f : dir.listFiles()) {
 			if (!f.isDirectory() && Pattern.matches(regex, f.getName())) {
 				return f;
-			} else if (f.isDirectory() && !imagesInputDirectories.contains(f.getName())) {
+			} else if (f.isDirectory() &&
+				!imagesInputDirectories.contains(f.getName()) &&
+				!fontsInputDirectories.contains(f.getName())) {
 				File sf = searchForData(f, regex);
 				if (sf != null) {
 					return sf;


### PR DESCRIPTION
I have a Docx file that, when converting to XHTML, fails with this error message:

```
Error occured. Please check the filetype and try again.?
Error: class pl.psnc.dl.ege.exception.ConverterException

Something went wrong with copying and downloading images. Please try again and if the problem persists, contact support or try converting your document with option
```

The trace goes something like this:

```
[Fatal Error] font2.odttf:1:1: Content is not allowed in prolog.
org.xml.sax.SAXParseException; systemId: file:/var/cache/oxgarage/temp/bb5233a7-cbd7-43a6-97e3-0befa352a441/fonts/font2.odttf; lineNumber: 1; columnNumber: 1; Content is not allowed in prolog.
	at org.apache.xerces.parsers.DOMParser.parse(Unknown Source)
	at org.apache.xerces.jaxp.DocumentBuilderImpl.parse(Unknown Source)
	at javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:205)
	at org.tei.utils.XMLUtils.readInputFileIntoJAXPDoc(XMLUtils.java:103)
	at pl.psnc.dl.ege.tei.ImageFetcher.getChangedNode(ImageFetcher.java:88)
	at pl.psnc.dl.ege.tei.TEIConverter.getImages(TEIConverter.java:1011)
	at pl.psnc.dl.ege.tei.TEIConverter.performXsltTransformation(TEIConverter.java:536)
	at pl.psnc.dl.ege.tei.TEIConverter.convertDocument(TEIConverter.java:275)
	at pl.psnc.dl.ege.tei.TEIConverter.convert(TEIConverter.java:151)
	at pl.psnc.dl.ege.component.NamedConverter.convert(NamedConverter.java:44)
	at pl.psnc.dl.ege.ConversionPerformer.run(ConversionPerformer.java:44)
	at java.lang.Thread.run(Thread.java:745)
16650 [Thread-5] ERROR pl.psnc.dl.ege.ConversionPerformer  - Something went wrong with copying and downloading images. Please try again and if the problem persists, contact support or try converting your document with option "Convert text only"
16652 [http-bio-8080-exec-1] ERROR pl.psnc.dl.ege.EGEImpl  - Something went wrong with copying and downloading images. Please try again and if the problem persists, contact support or try converting your document with option "Convert text only"
pl.psnc.dl.ege.exception.ConverterException: Something went wrong with copying and downloading images. Please try again and if the problem persists, contact support or try converting your document with option "Convert text only"
	at pl.psnc.dl.ege.tei.ImageFetcher.getChangedNode(ImageFetcher.java:173)
	at pl.psnc.dl.ege.tei.TEIConverter.getImages(TEIConverter.java:1011)
	at pl.psnc.dl.ege.tei.TEIConverter.performXsltTransformation(TEIConverter.java:536)
	at pl.psnc.dl.ege.tei.TEIConverter.convertDocument(TEIConverter.java:275)
	at pl.psnc.dl.ege.tei.TEIConverter.convert(TEIConverter.java:151)
	at pl.psnc.dl.ege.component.NamedConverter.convert(NamedConverter.java:44)
	at pl.psnc.dl.ege.ConversionPerformer.run(ConversionPerformer.java:44)
	at java.lang.Thread.run(Thread.java:745)
```

This Docx file has a fonts directory at `./word/fonts`, which contains a number of `.odttf` files. Looks like OxGarage is trying to load a font `.odttf` file as an XML, which raises a `Content is not allowed in prolog` exception that bubbles up and fails the conversion.

I've decided to use a similar approach as you're currently using for ignoring images as input files. This builds nicely and fixes the issue for me.

Let me know if you need the actual Docx to test, I can email it to you (saving the file in my version of Word removes the fonts files and links, and it's a private document, so I can't publicly attach it in its entirety.)
